### PR TITLE
Fix annoying bug where target file would be invalid due to process.cwd having changed in index

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -24,12 +24,14 @@ ${' '.repeat(info.description.length)
   const path = require('path');
   let dest = argv.filter(arg => !/^-/.test(arg))[3];
   source = path.resolve(process.cwd(), source);
+  if (dest) {
+    dest = path.resolve(process.cwd(), dest)
+  }
   fs.stat(source, (err, stat) => {
     if (err) throw err;
     if (!stat.isFile()) throw `unknown file ${source}`;
     const result = asbundle(source);
     if (dest) {
-      dest = path.resolve(process.cwd(), dest);
       fs.writeFileSync(dest, result);
     }
     else process.stdout.write(result);

--- a/index.js
+++ b/index.js
@@ -116,7 +116,13 @@ const parse = (options, base, file, cache, modules) => {
       const module = item.arguments[0];
       if (IGNORE.indexOf(module.value) < 0) {
         if (/^[./]/.test(module.value)) {
-          const name = require.resolve(path.resolve(base, module.value));
+          let name
+          try {
+            name = require.resolve(path.resolve(base, module.value));
+          } catch (e) {
+            process.stderr.write('Error resolving ' + module.value + ' from ' + base + ': ' + e.message)
+            throw e
+          }
           if (/\.m?js$/.test(name)) addChunk(module, name);
           else {
             const i = cache.indexOf(name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asbundle",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A minimalistic CommonJS bundler",
   "bin": "bin.js",
   "main": "index.js",


### PR DESCRIPTION
Changes:

* Fix an annoying bug where target file would fail to resolve to valid path because process.cwd had been changed in index.js
* Add error message on resolve failure with the source folder. Makes it a lot easier to debug or find the file in question